### PR TITLE
Scaffold front page

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -32,7 +32,7 @@ if ($posts) {
 <?php
       if (!empty($event_cats)) {
 ?>
-          <div class="font-serif"><?php echo $event_cats[0]; ?></div>
+          <div class="font-sans"><?php echo $event_cats[0]->name; ?></div>
 <?php
       }
 ?>
@@ -76,38 +76,32 @@ if ($posts) {
 // WORK
 
     if ($post_type == 'work') {
+      $work_cats = wp_get_post_terms($post_id, 'work_cat');
       $work_info = get_post_meta($post_id, '_igv_work_info', true);
       $work_artists = get_post_artists($post_id);
 
-      $classes = 'grid-item item-s-12 item-m-4 item-l-4 margin-bottom-mid ';
-
       if (!isset($posts[$i-1])) {
         // This is the first post
-        $classes .= 'offset-m-8 offset-l-8';
 ?>
-      <div class="grid-row">
+      <div class="grid-row justify-end">
 <?php
       } else {
         // This is not the first post
         if ($posts[$i-1]->post_type != 'event') {
           // but the previous was not Event
-          $classes .= 'offset-m-8 offset-l-8';
 ?>
-      <div class="grid-row">
+      <div class="grid-row justify-end">
 <?php
-        } else {
-          // and the previous was Event
-          $classes .= 'offset-m-1 offset-l-2';
         }
       }
 ?>
 
-        <article <?php post_class($classes, $post_id); ?> id="post-<?php echo $post_id; ?>">
+        <article <?php post_class('grid-item item-s-12 item-m-4 item-l-4 margin-bottom-mid offset-m-1 offset-l-2', $post_id); ?> id="post-<?php echo $post_id; ?>">
 
 <?php
-      if ($event_cats) {
+      if ($work_cats) {
 ?>
-          <div class="font-serif"><?php echo $event_cats[0]; ?></div>
+          <div class="font-sans"><?php echo $work_cats[0]->name; ?></div>
 <?php
       }
 ?>

--- a/front-page.php
+++ b/front-page.php
@@ -1,0 +1,92 @@
+<?php
+get_header();
+?>
+
+<main id="main-content">
+  <section id="posts">
+    <div class="container">
+
+<?php
+$posts = front_page_posts();
+
+if ($posts) {
+  $i = 0;
+
+  while ($i < count($posts)) {
+    $post_id = $posts[$i]->ID;
+    $post_type = $posts[$i]->post_type;
+
+    if ($post_type == 'event') {
+?>
+      <div class="grid-row">
+
+        <article <?php post_class('grid-item item-s-12 item-m-7 item-l-6', $post_id); ?> id="post-<?php echo $post_id; ?>">
+
+          <a href="<?php echo get_the_permalink($post_id) ?>"><?php echo get_the_title($post_id); ?></a>
+
+          <?php echo get_the_content($post_id); ?>
+
+        </article>
+
+<?php
+      if (!isset($posts[$i+1])) {
+?>
+      </div>
+<?php
+      } else {
+        if ($posts[$i+1]->post_type != 'work') {
+?>
+      </div>
+<?php
+        }
+      }
+    }
+
+    if ($post_type == 'work') {
+      $classes = 'grid-item item-s-12 item-m-4 offset-m-1 item-l-4 offset-l-2';
+
+      if (!isset($posts[$i-1])) {
+        $classes = 'grid-item item-s-12 item-m-4 offset-m-8 item-l-4 offset-l-8';
+?>
+      <div class="grid-row">
+<?php
+      } else {
+        if ($posts[$i-1]->post_type != 'event') {
+          $classes = 'grid-item item-s-12 item-m-4 offset-m-8 item-l-4 offset-l-8';
+?>
+      <div class="grid-row">
+<?php
+        }
+      }
+?>
+
+        <article <?php post_class($classes, $post_id); ?> id="post-<?php echo $post_id; ?>">
+
+          <a href="<?php echo get_the_permalink($post_id) ?>"><?php echo get_the_title($post_id); ?></a>
+
+          <?php echo get_the_content($post_id); ?>
+
+        </article>
+
+      </div>
+
+<?php
+    }
+    $i++;
+  }
+} else {
+?>
+        <article class="u-alert grid-item item-s-12"><?php _e('Sorry, no posts matched your criteria :{'); ?></article>
+<?php
+}
+?>
+
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<?php
+get_footer();
+?>

--- a/front-page.php
+++ b/front-page.php
@@ -3,7 +3,7 @@ get_header();
 ?>
 
 <main id="main-content">
-  
+
   <section id="posts">
     <div class="container">
 
@@ -30,7 +30,7 @@ if ($posts) {
         <article <?php post_class('grid-item item-s-12 item-m-7 item-l-6 margin-bottom-mid', $post_id); ?> id="post-<?php echo $post_id; ?>">
 
 <?php
-      if ($event_cats) {
+      if (!empty($event_cats)) {
 ?>
           <div class="font-serif"><?php echo $event_cats[0]; ?></div>
 <?php

--- a/front-page.php
+++ b/front-page.php
@@ -3,6 +3,7 @@ get_header();
 ?>
 
 <main id="main-content">
+  
   <section id="posts">
     <div class="container">
 
@@ -16,25 +17,54 @@ if ($posts) {
     $post_id = $posts[$i]->ID;
     $post_type = $posts[$i]->post_type;
 
+
+// EVENT
+
     if ($post_type == 'event') {
+      $event_cats = wp_get_post_terms($post_id, 'event_cat');
+      $event_artists = get_post_artists($post_id);
+      $event_date_location = event_date_location($post_id);
 ?>
       <div class="grid-row">
 
-        <article <?php post_class('grid-item item-s-12 item-m-7 item-l-6', $post_id); ?> id="post-<?php echo $post_id; ?>">
+        <article <?php post_class('grid-item item-s-12 item-m-7 item-l-6 margin-bottom-mid', $post_id); ?> id="post-<?php echo $post_id; ?>">
 
-          <a href="<?php echo get_the_permalink($post_id) ?>"><?php echo get_the_title($post_id); ?></a>
+<?php
+      if ($event_cats) {
+?>
+          <div class="font-serif"><?php echo $event_cats[0]; ?></div>
+<?php
+      }
+?>
 
-          <?php echo get_the_content($post_id); ?>
+          <h2 class="font-serif font-italic"><a href="<?php echo get_the_permalink($post_id) ?>"><?php echo get_the_title($post_id); ?></a></h2>
+
+<?php
+      if (!empty($event_artists)) {
+?>
+          <div class="font-serif"><?php echo $event_artists; ?></div>
+<?php
+      }
+
+      if (!empty($event_date_location)) {
+?>
+          <div class="font-sans margin-top-small"><?php _e($event_date_location); ?></div>
+<?php
+      }
+?>
 
         </article>
 
 <?php
       if (!isset($posts[$i+1])) {
+        // This is the last post
 ?>
       </div>
 <?php
       } else {
+        // This is not the last post
         if ($posts[$i+1]->post_type != 'work') {
+          // but the next post is not Work
 ?>
       </div>
 <?php
@@ -42,29 +72,61 @@ if ($posts) {
       }
     }
 
+
+// WORK
+
     if ($post_type == 'work') {
-      $classes = 'grid-item item-s-12 item-m-4 offset-m-1 item-l-4 offset-l-2';
+      $work_info = get_post_meta($post_id, '_igv_work_info', true);
+      $work_artists = get_post_artists($post_id);
+
+      $classes = 'grid-item item-s-12 item-m-4 item-l-4 margin-bottom-mid ';
 
       if (!isset($posts[$i-1])) {
-        $classes = 'grid-item item-s-12 item-m-4 offset-m-8 item-l-4 offset-l-8';
+        // This is the first post
+        $classes .= 'offset-m-8 offset-l-8';
 ?>
       <div class="grid-row">
 <?php
       } else {
+        // This is not the first post
         if ($posts[$i-1]->post_type != 'event') {
-          $classes = 'grid-item item-s-12 item-m-4 offset-m-8 item-l-4 offset-l-8';
+          // but the previous was not Event
+          $classes .= 'offset-m-8 offset-l-8';
 ?>
       <div class="grid-row">
 <?php
+        } else {
+          // and the previous was Event
+          $classes .= 'offset-m-1 offset-l-2';
         }
       }
 ?>
 
         <article <?php post_class($classes, $post_id); ?> id="post-<?php echo $post_id; ?>">
 
-          <a href="<?php echo get_the_permalink($post_id) ?>"><?php echo get_the_title($post_id); ?></a>
+<?php
+      if ($event_cats) {
+?>
+          <div class="font-serif"><?php echo $event_cats[0]; ?></div>
+<?php
+      }
+?>
 
-          <?php echo get_the_content($post_id); ?>
+          <h2 class="font-serif font-italic"><a href="<?php echo get_the_permalink($post_id) ?>"><?php echo get_the_title($post_id); ?></a></h2>
+
+<?php
+      if (!empty($work_artists)) {
+?>
+          <div class="font-serif"><?php echo $work_artists; ?></div>
+<?php
+      }
+
+      if (!empty($work_info)) {
+?>
+          <div class="font-sans margin-top-small"><?php echo $work_info; ?></div>
+<?php
+      }
+?>
 
         </article>
 
@@ -72,16 +134,13 @@ if ($posts) {
 
 <?php
     }
+
     $i++;
   }
-} else {
-?>
-        <article class="u-alert grid-item item-s-12"><?php _e('Sorry, no posts matched your criteria :{'); ?></article>
-<?php
+
 }
 ?>
 
-      </div>
     </div>
   </section>
 

--- a/index.php
+++ b/index.php
@@ -2,8 +2,6 @@
 get_header();
 ?>
 
-<?php get_template_part('partials/demo'); ?>
-
 <main id="main-content">
   <section id="posts">
     <div class="container">

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -1,3 +1,78 @@
 <?php
 
 // Custom functions (like special queries, etc)
+
+function front_page_posts() {
+  $args = array(
+    'post_type'       =>  array('event'),
+    'posts_per_page'  =>  '-1',
+    'meta_key'        =>  '_igv_event_start_date',
+    'meta_query'      =>  array(
+      array(
+        'key'     =>  '_igv_event_show_home',
+        'value'   =>  'on',
+        'compare' =>  '='
+      )
+    )
+  );
+
+  $events = get_posts( $args );
+
+  $args = array(
+    'post_type'       =>  array('work'),
+    'posts_per_page'  =>  '-1',
+    'meta_query'      =>  array(
+      array(
+        'key'     =>  '_igv_work_show_home',
+        'value'   =>  'on',
+        'compare' =>  '='
+      )
+    )
+  );
+
+  $works = get_posts( $args );
+
+  $posts = array();
+
+  if ($events || $works) {
+    $total = count($events) + count($works);
+
+    $total_counter = 0;
+    $events_counter = 0;
+    $works_counter = 0;
+
+    // iterate over total num of posts
+    while ($total_counter < $total) {
+
+      // if event, add to posts array
+      if (isset($events[$events_counter])) {
+        $posts[] = $events[$events_counter];
+      }
+
+      // if work, add to posts array
+      if (isset($works[$works_counter])) {
+        $posts[] = $works[$works_counter];
+      }
+
+      // increment counters
+      if (isset($events[$events_counter]) && isset($works[$works_counter])) {
+        // increment both
+        $events_counter++;
+        $works_counter++;
+      } else {
+        // increment individual
+        if (isset($events[$events_counter])) {
+          $events_counter++;
+        }
+        if (isset($works[$works_counter])) {
+          $works_counter++;
+        }
+      }
+
+      // total counters
+      $total_counter = $events_counter + $works_counter;
+    }
+  }
+
+  return $posts;
+}

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -68,7 +68,10 @@ function event_date_location($post_id) {
 // of Event and Work posts for Home
 // alterneting 1 event, 1 work
 function front_page_posts() {
-  $args = array(
+
+  // Get events marked as Show on home sort by
+  // start_date, start_date should not be empty
+  $events_args = array(
     'post_type'       =>  array('event'),
     'posts_per_page'  =>  '-1',
     'meta_key'        =>  '_igv_event_start_date',
@@ -81,9 +84,10 @@ function front_page_posts() {
     )
   );
 
-  $events = get_posts( $args );
+  $events = get_posts( $events_args );
 
-  $args = array(
+
+  $works_args = array(
     'post_type'       =>  array('work'),
     'posts_per_page'  =>  '-1',
     'meta_query'      =>  array(
@@ -95,7 +99,7 @@ function front_page_posts() {
     )
   );
 
-  $works = get_posts( $args );
+  $works = get_posts( $works_args );
 
   $posts = array();
 

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -66,6 +66,7 @@ function event_date_location($post_id) {
 
 // Retrieve, sort, and return array
 // of Event and Work posts for Home
+// alterneting 1 event, 1 work
 function front_page_posts() {
   $args = array(
     'post_type'       =>  array('event'),
@@ -98,7 +99,7 @@ function front_page_posts() {
 
   $posts = array();
 
-  if ($events || $works) {
+  if (!empty($events) || !empty($works)) {
     $total = count($events) + count($works);
 
     $total_counter = 0;

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -2,6 +2,70 @@
 
 // Custom functions (like special queries, etc)
 
+// Return string of Artists
+function get_post_artists($post_id) {
+  $artist_terms = wp_get_post_terms($post_id, 'artist');
+  $count_terms = count($artist_terms);
+
+  $artists = '';
+
+  for ($i=0; $i < $count_terms; $i++) {
+    $artists .= $artist_terms[$i]->name;
+
+    if ($count_terms > 1 && ($i + 1) !== $count_terms) {
+      if (($i + 2) === $count_terms) {
+        $artists .= ' & ';
+      } else {
+        $artists .= ', ';
+      }
+    }
+  }
+
+  return $artists;
+}
+
+// Return string of Event dates & location
+function event_date_location($post_id) {
+  $date_location = '';
+
+  $show_dates = get_post_meta($post_id, '_igv_event_show_dates', true);
+  $location_terms = wp_get_post_terms($post_id, 'location');
+
+  if (!empty($show_dates)) {
+    $start_time = get_post_meta($post_id, '_igv_event_start_date', true);
+    $end_time = get_post_meta($post_id, '_igv_event_end_date', true);
+
+    if (!empty($start_time)) {
+      $date_location .= translate_datetime('j F, Y', $start_time);
+
+      if (!empty($end_time)) {
+        $date_location .= ' — ' . translate_datetime('j F, Y', $end_time);
+      }
+
+      if ($location_terms) {
+        $date_location .= ' ';
+      }
+    }
+
+  }
+
+  if ($location_terms) {
+    $location = $location_terms[0]->name;
+    $location_class = '.location-' . $location_terms[0]->slug;
+    $city = get_term_meta($location_terms[0]->term_id, '_igv_location_city', true);
+
+    $date_location .= '[:en]at[:es]en[:] <span class="' . $location_class . '">' . $location . '</span>';
+
+    if (!empty($city)) {
+      $date_location .= ', ' . $city;
+    }
+  }
+
+  return $date_location;
+}
+
+// Retrieve, sort, and return array
+// of Event and Work posts for Home
 function front_page_posts() {
   $args = array(
     'post_type'       =>  array('event'),

--- a/lib/functions-utility.php
+++ b/lib/functions-utility.php
@@ -74,3 +74,8 @@ function echo_post_meta($post_id, $field_id) {
     echo '';
   }
 }
+
+// Wrapper function for qTranslateX date conversion
+function translate_datetime($format, $datetime) {
+  return qtranxf_strftime(qtranxf_convertFormat($format, $format), $datetime, '');
+}

--- a/lib/meta-boxes.php
+++ b/lib/meta-boxes.php
@@ -48,6 +48,13 @@ function igv_cmb_metaboxes() {
   ) );
 
   $event_metabox->add_field( array(
+    'name' => esc_html__( 'Show on Home', 'cmb2' ),
+    'id'   => $prefix . 'event_show_home',
+    'type' => 'checkbox',
+    'column'  => true,
+  ) );
+
+  $event_metabox->add_field( array(
     'name' => esc_html__( 'Start Date', 'cmb2' ),
     'id'   => $prefix . 'event_start_date',
     'type' => 'text_date_timestamp',
@@ -82,6 +89,13 @@ function igv_cmb_metaboxes() {
     'object_types'  => array( 'work' ), // Post type
   ) );
 
+  $event_metabox->add_field( array(
+    'name' => esc_html__( 'Show on Home', 'cmb2' ),
+    'id'   => $prefix . 'work_show_home',
+    'type' => 'checkbox',
+    'column'  => true,
+  ) );
+
   $work_metabox->add_field( array(
     'name' => esc_html__( 'Inventory #', 'cmb2' ),
     'id'   => $prefix . 'work_inventory',
@@ -104,6 +118,20 @@ function igv_cmb_metaboxes() {
     'attributes' => array(
       'data-cmb2-qtranslate' => true,
     ),
+  ) );
+
+  $work_metabox->add_field( array(
+    'name' => esc_html__( 'Work', 'cmb2' ),
+    'id'   => $prefix . 'work_images_works',
+    'type' => 'file_list',
+    'preview_size' => array( 150, 150 ),
+  ) );
+
+  $work_metabox->add_field( array(
+    'name' => esc_html__( 'Installation views', 'cmb2' ),
+    'id'   => $prefix . 'work_images_install',
+    'type' => 'file_list',
+    'preview_size' => array( 150, 150 ),
   ) );
 
 

--- a/lib/meta-boxes.php
+++ b/lib/meta-boxes.php
@@ -67,6 +67,12 @@ function igv_cmb_metaboxes() {
   ) );
 
   $event_metabox->add_field( array(
+    'name' => esc_html__( 'Show dates', 'cmb2' ),
+    'id'   => $prefix . 'event_show_dates',
+    'type' => 'checkbox',
+  ) );
+
+  $event_metabox->add_field( array(
     'name' => esc_html__( 'Installation views', 'cmb2' ),
     'id'   => $prefix . 'event_images_install',
     'type' => 'file_list',
@@ -89,7 +95,7 @@ function igv_cmb_metaboxes() {
     'object_types'  => array( 'work' ), // Post type
   ) );
 
-  $event_metabox->add_field( array(
+  $work_metabox->add_field( array(
     'name' => esc_html__( 'Show on Home', 'cmb2' ),
     'id'   => $prefix . 'work_show_home',
     'type' => 'checkbox',

--- a/lib/meta-boxes.php
+++ b/lib/meta-boxes.php
@@ -80,7 +80,7 @@ function igv_cmb_metaboxes() {
   ) );
 
   $event_metabox->add_field( array(
-    'name' => esc_html__( 'Works', 'cmb2' ),
+    'name' => esc_html__( 'Work images', 'cmb2' ),
     'id'   => $prefix . 'event_images_works',
     'type' => 'file_list',
     'preview_size' => array( 150, 150 ),
@@ -127,7 +127,7 @@ function igv_cmb_metaboxes() {
   ) );
 
   $work_metabox->add_field( array(
-    'name' => esc_html__( 'Work', 'cmb2' ),
+    'name' => esc_html__( 'Work images', 'cmb2' ),
     'id'   => $prefix . 'work_images_works',
     'type' => 'file_list',
     'preview_size' => array( 150, 150 ),

--- a/lib/taxonomies.php
+++ b/lib/taxonomies.php
@@ -17,7 +17,7 @@ function create_location_tax() {
     'update_item'                => __( 'Update Location' ),
     'add_new_item'               => __( 'Add New Location' ),
     'new_item_name'              => __( 'New Location Name' ),
-    'separate_items_with_commas' => __( 'Separate Locations with commas' ),
+    'separate_items_with_commas' => __( 'Use only 1 Location' ),
     'add_or_remove_items'        => __( 'Add or remove Location' ),
     'choose_from_most_used'      => __( 'Choose from the most used Locations' ),
     'not_found'                  => __( 'No Locations found.' ),
@@ -69,4 +69,76 @@ function create_artist_tax() {
   );
 
   register_taxonomy( 'artist', array('event', 'work', 'cv'), $args );
+}
+
+
+// EVENT TYPES
+
+add_action( 'init', 'create_event_cat_tax' );
+
+function create_event_cat_tax() {
+  $labels = array(
+    'name'                       => _x( 'Types', 'taxonomy general name' ),
+    'singular_name'              => _x( 'Type', 'taxonomy singular name' ),
+    'search_items'               => __( 'Search Types' ),
+    'popular_items'              => __( 'Popular Types' ),
+    'all_items'                  => __( 'All Types' ),
+    'parent_item'                => null,
+    'parent_item_colon'          => null,
+    'edit_item'                  => __( 'Edit Type' ),
+    'update_item'                => __( 'Update Type' ),
+    'add_new_item'               => __( 'Add New Type' ),
+    'new_item_name'              => __( 'New Type Name' ),
+    'separate_items_with_commas' => __( 'Use only 1 Type' ),
+    'add_or_remove_items'        => __( 'Add or remove Type' ),
+    'choose_from_most_used'      => __( 'Choose from the most used Types' ),
+    'not_found'                  => __( 'No Types found.' ),
+    'menu_name'                  => __( 'Types' ),
+  );
+
+  $args = array(
+    'hierarchical'          => false,
+    'labels'                => $labels,
+    'show_ui'               => true,
+    'show_admin_column'     => true,
+    'query_var'             => true,
+  );
+
+  register_taxonomy( 'event_cat', array('event'), $args );
+}
+
+
+// WORK TYPES
+
+add_action( 'init', 'create_work_cat_tax' );
+
+function create_work_cat_tax() {
+  $labels = array(
+    'name'                       => _x( 'Types', 'taxonomy general name' ),
+    'singular_name'              => _x( 'Type', 'taxonomy singular name' ),
+    'search_items'               => __( 'Search Types' ),
+    'popular_items'              => __( 'Popular Types' ),
+    'all_items'                  => __( 'All Types' ),
+    'parent_item'                => null,
+    'parent_item_colon'          => null,
+    'edit_item'                  => __( 'Edit Type' ),
+    'update_item'                => __( 'Update Type' ),
+    'add_new_item'               => __( 'Add New Type' ),
+    'new_item_name'              => __( 'New Type Name' ),
+    'separate_items_with_commas' => __( 'Use only 1 Type' ),
+    'add_or_remove_items'        => __( 'Add or remove Type' ),
+    'choose_from_most_used'      => __( 'Choose from the most used Types' ),
+    'not_found'                  => __( 'No Types found.' ),
+    'menu_name'                  => __( 'Types' ),
+  );
+
+  $args = array(
+    'hierarchical'          => false,
+    'labels'                => $labels,
+    'show_ui'               => true,
+    'show_admin_column'     => true,
+    'query_var'             => true,
+  );
+
+  register_taxonomy( 'work_cat', array('work'), $args );
 }


### PR DESCRIPTION
made some functions to return formatted post data

had to do some funny array juggling to get `event` and `work` posts to alternate. in the design `events` are to the left and `work` to the right, but they need to be in the same row to line up. also on mobile I want them to alternate rather than the `work` posts being pushed to the bottom.